### PR TITLE
Fix color stripping method

### DIFF
--- a/src/main/java/com/iridium/iridiumcolorapi/IridiumColorAPI.java
+++ b/src/main/java/com/iridium/iridiumcolorapi/IridiumColorAPI.java
@@ -177,7 +177,7 @@ public class IridiumColorAPI {
      */
     @Nonnull
     public static String stripColorFormatting(@Nonnull String string) {
-        return string.replaceAll("[&§][a-f0-9lnokm]|<[/]?\\w{5,8}(:[0-9A-F]{6})?>", "");
+        return string.replaceAll("[&§][a-f0-9lnokm]|<[/]?[A-Z]{5,8}(:[0-9A-F]{6})?>", "");
     }
 
     /**


### PR DESCRIPTION
Fixes `<player>` and similar things getting detected as a color pattern. <PLAYER> will still be detected but I believe this is the best solution without hardcoding the pattern names.

Additionally strips away the new `<#HEX>` format.