### PR TITLE
Fix a problem where the API did not recognize already converted color…

### DIFF
--- a/src/main/java/com/iridium/iridiumcolorapi/IridiumColorAPI.java
+++ b/src/main/java/com/iridium/iridiumcolorapi/IridiumColorAPI.java
@@ -34,7 +34,7 @@ public class IridiumColorAPI {
      */
     private static final boolean SUPPORTS_RGB = VERSION >= 16;
 
-    private static final List<String> SPECIAL_COLORS = Arrays.asList("&l", "&n", "&o", "&k", "&m");
+    private static final List<String> SPECIAL_COLORS = Arrays.asList("&l", "&n", "&o", "&k", "&m","§l", "§n", "§o", "§k", "§m");
 
     /**
      * Cached result of all legacy colors.


### PR DESCRIPTION
I found out that 
```java
IridiumColorAPI.process("<RAINBOW1>&kRAINBOW</RAINBOW>")
```
worked, but
```java
IridiumColorAPI.process("<RAINBOW1>§kRAINBOW</RAINBOW>")
```
this one wrote the letter K instead. If anything (In my case Skript) pre convert & to §, then the API cannot recognize special codes. 