### PR TITLE
Improve provide Rainbow text

### DIFF
--- a/src/main/java/com/iridium/iridiumcolorapi/patterns/RainbowPattern.java
+++ b/src/main/java/com/iridium/iridiumcolorapi/patterns/RainbowPattern.java
@@ -22,10 +22,14 @@ public class RainbowPattern implements Pattern {
 			String colon = matcher.group(1);
 			String saturation = matcher.group(1);
 			String content = matcher.group(2);
+
 			if (colon.equals(":")) {
 				string = string.replace(matcher.group(), IridiumColorAPI.rainbow(content, Float.parseFloat(saturation)));
 			} else {
-				string = string.replace(matcher.group(), IridiumColorAPI.rainbow(content, Float.parseFloat("1")));
+				if (saturation.isEmpty()) {
+					string = string.replace(matcher.group(), IridiumColorAPI.rainbow(content, Float.parseFloat("1")));
+				} else
+					string = string.replace(matcher.group(), IridiumColorAPI.rainbow(content, Float.parseFloat(saturation)));
 
 			}
 		}

--- a/src/main/java/com/iridium/iridiumcolorapi/patterns/RainbowPattern.java
+++ b/src/main/java/com/iridium/iridiumcolorapi/patterns/RainbowPattern.java
@@ -6,23 +6,30 @@ import java.util.regex.Matcher;
 
 public class RainbowPattern implements Pattern {
 
-    java.util.regex.Pattern pattern = java.util.regex.Pattern.compile("<RAINBOW([0-9]{1,3})>(.*?)</RAINBOW>");
+	java.util.regex.Pattern pattern = java.util.regex.Pattern.compile("<RAINBOW(|:)(|[0-9]{1,3})>(.*?)</RAINBOW>");
 
-    /**
-     * Applies a rainbow pattern to the provided String.
-     * Output might me the same as the input if this pattern is not present.
-     *
-     * @param string The String to which this pattern should be applied to
-     * @return The new String with applied pattern
-     */
-    public String process(String string) {
-        Matcher matcher = pattern.matcher(string);
-        while (matcher.find()) {
-            String saturation = matcher.group(1);
-            String content = matcher.group(2);
-            string = string.replace(matcher.group(), IridiumColorAPI.rainbow(content, Float.parseFloat(saturation)));
-        }
-        return string;
-    }
+	/**
+	 * Applies a rainbow pattern to the provided String.
+	 * Output might me the same as the input if this pattern is not present.
+	 *
+	 * @param string The String to which this pattern should be applied to
+	 * @return The new String with applied pattern
+	 */
+	@Override
+	public String process(String string) {
+		Matcher matcher = pattern.matcher(string);
+		while (matcher.find()) {
+			String colon = matcher.group(1);
+			String saturation = matcher.group(1);
+			String content = matcher.group(2);
+			if (colon.equals(":")) {
+				string = string.replace(matcher.group(), IridiumColorAPI.rainbow(content, Float.parseFloat(saturation)));
+			} else {
+				string = string.replace(matcher.group(), IridiumColorAPI.rainbow(content, Float.parseFloat("1")));
+
+			}
+		}
+		return string;
+	}
 
 }


### PR DESCRIPTION
This no require provide saturation.
So now you can use `<RAINBOW>Message</RAINBOW>` without providing saturation and default will be 1 or you can provide saturation `<RAINBOW:saturation>Message</RAINBOW>`.

But now if you want provide saturation you need put `:` before saturation like in other Patterns.

This look better and saturation is optional in message.