### PR TITLE
fix: single char error

### DIFF
--- a/src/main/java/com/iridium/iridiumcolorapi/IridiumColorAPI.java
+++ b/src/main/java/com/iridium/iridiumcolorapi/IridiumColorAPI.java
@@ -232,6 +232,7 @@ public class IridiumColorAPI {
      */
     @Nonnull
     private static ChatColor[] createGradient(@Nonnull Color start, @Nonnull Color end, int step) {
+        step = Math.max(step,2);
         ChatColor[] colors = new ChatColor[step];
         int stepR = Math.abs(start.getRed() - end.getRed()) / (step - 1);
         int stepG = Math.abs(start.getGreen() - end.getGreen()) / (step - 1);


### PR DESCRIPTION
Fix when there only one char in gradient (for example because of player level integer) message doesn't appear and console info error
