### PR TITLE
Improve server version parsing for Minecraft 26.1+ builds

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,8 +14,9 @@ repositories {
 }
 
 dependencies {
-    implementation("org.spigotmc:spigot:1.17.1")
+    compileOnly("org.spigotmc:spigot:1.17.1")
     implementation("org.apache.commons:commons-lang3:3.13.0")
+    testImplementation("org.spigotmc:spigot:1.17.1")
     testImplementation("org.junit.jupiter:junit-jupiter:5.8.1")
     testImplementation("org.mockito:mockito-inline:4.0.0")
     testImplementation("org.mockito:mockito-junit-jupiter:4.0.0")

--- a/src/main/java/com/iridium/iridiumcolorapi/IridiumColorAPI.java
+++ b/src/main/java/com/iridium/iridiumcolorapi/IridiumColorAPI.java
@@ -291,20 +291,26 @@ public class IridiumColorAPI {
         String version = Bukkit.getVersion();
         Validate.notEmpty(version, "Cannot get major Minecraft version from null or empty string");
 
-        // getVersion()
         int index = version.lastIndexOf("MC:");
         if (index != -1) {
-            version = version.substring(index + 4, version.length() - 1);
-        } else if (version.endsWith("SNAPSHOT")) {
-            // getBukkitVersion()
+            int endIndex = version.indexOf(')', index);
+            version = version.substring(index + 3, endIndex == -1 ? version.length() : endIndex).trim();
+        } else {
             index = version.indexOf('-');
-            version = version.substring(0, index);
-        }
-        // 1.13.2, 1.14.4, etc...
-        int lastDot = version.lastIndexOf('.');
-        if (version.indexOf('.') != lastDot) version = version.substring(0, lastDot);
 
-        return Integer.parseInt(version.substring(2));
+            if (index != -1) {
+                version = version.substring(0, index);
+            }
+        }
+
+        String[] parts = version.trim().split("\\.");
+        Validate.isTrue(parts.length > 0, "Cannot extract major Minecraft version from %s", version);
+
+        if (parts.length > 1 && "1".equals(parts[0])) {
+            return Integer.parseInt(parts[1]);
+        }
+
+        return Integer.parseInt(parts[0]);
     }
 
     /**

--- a/src/test/java/com/iridium/iridiumcolorapi/IridiumColorAPITest.java
+++ b/src/test/java/com/iridium/iridiumcolorapi/IridiumColorAPITest.java
@@ -4,10 +4,14 @@ import org.bukkit.Bukkit;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import java.awt.Color;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
 
@@ -76,6 +80,28 @@ class IridiumColorAPITest {
         assertEquals("<html>Test</html>", IridiumColorAPI.stripColorFormatting("<html>Test</html>"));
         assertEquals("<windows>Test</tests100>", IridiumColorAPI.stripColorFormatting("<windows>Test</tests100>"));
         assertEquals("&&&&&Test&&&&&", IridiumColorAPI.stripColorFormatting("&&&&&Test&&&&&"));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "1.8.8-R0.1-SNAPSHOT,8",
+            "1.12-R0.1-SNAPSHOT,12",
+            "1.20.6-R0.1-SNAPSHOT,20",
+            "git-Paper-43 (MC: 1.20.1),20",
+            "git-Purpur-2231 (MC: 1.16.5),16",
+            "26.1.2-R0.1-SNAPSHOT,26",
+            "26.1.2-49-main@7799bf2 (2026-04-26T20:59:50Z),26"
+    })
+    void getVersionParsesSupportedServerFormats(String version, int expected) throws Exception {
+        mockedStatic.when(Bukkit::getVersion).thenReturn(version);
+
+        assertEquals(expected, invokeGetVersion());
+    }
+
+    private static int invokeGetVersion() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        Method method = IridiumColorAPI.class.getDeclaredMethod("getVersion");
+        method.setAccessible(true);
+        return (int) method.invoke(null);
     }
 
     @AfterAll


### PR DESCRIPTION
## Summary

This PR fixes server version parsing in `IridiumColorAPI` for newer server version formats, including `26.1+` builds.

## What was happening

`IridiumColorAPI#getVersion()` was using a fragile parsing approach that assumed older version formats such as `1.x.x-R0.1-SNAPSHOT`.

With newer server versions, version strings can include different formats such as:

- `26.1.2-R0.1-SNAPSHOT`
- `26.1.2-49-main@7799bf2 (2026-04-26T20:59:50Z)`
- `git-Paper-43 (MC: 1.20.1)`

Because of that, the old logic could extract invalid substrings like `.1` and throw a `NumberFormatException` during static initialization.

## What changed

- Reworked `getVersion()` to extract the major version more safely
- Kept support for legacy `1.x.x` style versions
- Added support for newer multi-part version formats, including `26.1+` style builds
- Added broader test coverage for multiple real-world version strings

## Dependency metadata

This PR also updates the Spigot dependency setup so it is no longer published as a transitive runtime dependency.

The library only needs the Bukkit/Spigot API at compile time, while tests still keep access to it through the test configuration.